### PR TITLE
handle distance scenic rides

### DIFF
--- a/service/peloservice/model.go
+++ b/service/peloservice/model.go
@@ -26,7 +26,7 @@ type exportedWorkout struct {
 	StartTime          string  `csv:"Workout Timestamp"`
 	LiveOrOnDemand     string  `csv:"Live/On-Demand"`
 	Instructor         string  `csv:"Instructor Name"`
-	LengthMinutes      int     `csv:"Length (minutes)"`
+	LengthMinutes      string  `csv:"Length (minutes)"`
 	FitnessDiscipline  string  `csv:"Fitness Discipline"`
 	ClassType          string  `csv:"Type"`
 	ClassTitle         string  `csv:"Title"`
@@ -52,6 +52,7 @@ type workouts struct {
 type workout struct {
 	Id               string      `json:"id"`
 	StartTimeSeconds uint64      `json:"start_time"`
+	EndTimeSeconds   uint64      `json:"end_time"`
 	Timezone         string      `json:"timezone"`
 	CurrentPr        bool        `json:"is_total_work_personal_record"`
 	Wtype            string      `json:"fitness_discipline"`
@@ -62,7 +63,7 @@ type workout struct {
 }
 
 type effortZones struct {
-	TotalEffortPoints float64 `json:"total_effort_points"`
+	TotalEffortPoints      float64                `json:"total_effort_points"`
 	HeartRateZoneDurations heartRateZoneDurations `json:"heart_rate_zone_durations"`
 }
 
@@ -72,7 +73,6 @@ type heartRateZoneDurations struct {
 	HrZone3Seconds int `json:"heart_rate_z3_duration"`
 	HrZone4Seconds int `json:"heart_rate_z4_duration"`
 	HrZone5Seconds int `json:"heart_rate_z5_duration"`
-
 }
 
 // Workouts details returned from /api/workout/{id}

--- a/service/peloservice/model_test.go
+++ b/service/peloservice/model_test.go
@@ -1,8 +1,10 @@
 package peloservice
 
 import (
-	"testing"
 	"encoding/json"
+	"strconv"
+	"testing"
+
 	"github.com/gocarina/gocsv"
 )
 
@@ -85,7 +87,7 @@ func TestJson(t *testing.T) {
 func TestCsvUS(t *testing.T) {
 	workoutsResponse := []byte(`
 Workout Timestamp,Live/On-Demand,Instructor Name,Length (minutes),Fitness Discipline,Type,Title,Class Timestamp,Total Output,Avg. Watts,Avg. Resistance,Avg. Cadence (RPM),Avg. Speed (mph),Distance (mi),Calories Burned,Avg. Heartrate,Avg. Incline,Avg. Pace (min/mi)
-2018-02-22 17:25 (EST),Live,,15,Cycling,Scenic Ride,15 min Venice Scenic Ride,,46,52,25%,93,11.87,2.96,63,,,
+2018-02-22 17:25 (EST),Live,,25,Cycling,Ema Lovewell,15 min HIT,,46,52,25%,93,11.87,2.96,63,,,
 `)
 
 	var (
@@ -99,7 +101,7 @@ Workout Timestamp,Live/On-Demand,Instructor Name,Length (minutes),Fitness Discip
 		t.Fatal(err)
 	}
 
-	want = "15 min Venice Scenic Ride"
+	want = "15 min HIT"
 	got = workouts[0].ClassTitle
 	if got != want {
 		t.Fatalf("got: %s; want %s\n", got, want)
@@ -125,6 +127,39 @@ Workout Timestamp,Live/On-Demand,Instructor Name,Length (minutes),Fitness Discip
 
 	want = 15.63
 	got = workouts[0].DistanceKilometers
+	if got != want {
+		t.Fatalf("got: %s; want %s\n", got, want)
+	}
+}
+
+
+func TestCsvUSScenic(t *testing.T) {
+	workoutsResponse := []byte(`
+Workout Timestamp,Live/On-Demand,Instructor Name,Length (minutes),Fitness Discipline,Type,Title,Class Timestamp,Total Output,Avg. Watts,Avg. Resistance,Avg. Cadence (RPM),Avg. Speed (mph),Distance (mi),Calories Burned,Avg. Heartrate,Avg. Incline,Avg. Pace (min/mi)
+2018-02-22 17:25 (EST),Live,,None,Cycling,Scenic Ride,15 min Venice Scenic Ride,,46,52,25%,93,11.87,2.96,63,,,
+`)
+
+	var (
+		err        error
+		workouts   exportedWorkouts
+		want       interface{}
+		got        interface{}
+	)
+
+	if err = gocsv.UnmarshalBytes(workoutsResponse, &workouts); err != nil {
+		t.Fatal(err)
+	}
+
+	want = "15 min Venice Scenic Ride"
+	got = workouts[0].ClassTitle
+	if got != want {
+		t.Fatalf("got: %s; want %s\n", got, want)
+	}
+
+	want = 0
+	if got, err = strconv.Atoi(workouts[0].LengthMinutes); err != nil {
+		got = 0
+	}
 	if got != want {
 		t.Fatalf("got: %s; want %s\n", got, want)
 	}


### PR DESCRIPTION
Currently, there's no great way to get the duration of distance based scenic rides since the ride title is simply "Scenic Ride" in the call to the `/workouts` endpoint.  Therefore, I'm setting ride length minutes to 0 for now so that the rides still come through in the data set.